### PR TITLE
Fix README capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # speck
 
-A Python project for spectral data visualization using PyQt5, matplotlib, numpy, scipy, and pillow.
+A Python project for spectral data visualization using PyQt5, Matplotlib, NumPy, SciPy, and Pillow.
 
 ## Requirements
 - Python 3.x
-- pyqt5
-- matplotlib
-- numpy
-- scipy
-- pillow
+- PyQt5
+- Matplotlib
+- NumPy
+- SciPy
+- Pillow
 
 ## Installation
 Install the required packages:


### PR DESCRIPTION
## Summary
- standardize capitalization for third-party libraries in the project description and Requirements section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847f7fd811c832d86314913c4cfd87d