### PR TITLE
Sort spectra titles alphabetically

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,6 +177,11 @@
 
       entries
         .filter(([file]) => file.toLowerCase().endsWith('.csv'))
+        .sort((a, b) => {
+          const t1 = a[1] || a[0];
+          const t2 = b[1] || b[0];
+          return t1.localeCompare(t2, undefined, { sensitivity: 'base' });
+        })
         .forEach(([file, title]) => {
           spectraData[file] = `${DATA_DIR}/${file}`;
 


### PR DESCRIPTION
## Summary
- sort available spectrum titles alphabetically on page load

## Testing
- `python -m py_compile labparser.py spectra_lab_viewer.py`

------
https://chatgpt.com/codex/tasks/task_e_685010fc20ac832d823faa77dbf04af4