### PR TITLE
UI fixes for charts

### DIFF
--- a/compare.html
+++ b/compare.html
@@ -19,16 +19,16 @@
   button{transition:transform .2s}
   button:hover{transform:scale(1.05)}
   #ccdWrap canvas{width:100%!important;height:120px;margin-bottom:4px;border:1px solid #555}
-  #chartWrap{position:absolute;top:56px;bottom:0;left:0;right:0;padding:10px;background:#181818;border-top:1px solid #444}
+  #chartWrap{position:absolute;top:var(--topbar-h,56px);bottom:0;left:0;right:0;padding:10px;background:#181818;border-top:1px solid #444}
   #chartWrap canvas{cursor:crosshair}
   #cursorData{position:absolute;top:8px;right:12px;color:#fff;background:rgba(0,0,0,0.6);padding:2px 6px;border-radius:4px;font-size:.85rem;pointer-events:none}
   #ccdOverlay{
-    position:fixed;top:56px;left:0;right:0;bottom:0;
+    position:fixed;top:var(--topbar-h,56px);left:0;right:0;bottom:0;
     background:rgba(0,0,0,0.92);display:none;overflow-y:auto;padding:20px;
   }
   #ccdOverlay canvas{width:100%!important;height:140px;margin-bottom:10px;border:1px solid #555}
   #closeCCD{
-    position:fixed;top:60px;right:20px;padding:4px 8px;font-size:18px;
+    position:fixed;top:calc(var(--topbar-h,56px) + 4px);right:20px;padding:4px 8px;font-size:18px;
     background:#c0392b;border:none;color:#fff;border-radius:4px;cursor:pointer;
   }
   canvas{width:100%!important;height:100%!important}
@@ -121,6 +121,13 @@ const DATA_DIR  = 'csv_out';
 const LIST_FILE = 'titoli.json';
 // ==============
 
+function updateTop(){
+  document.documentElement.style.setProperty('--topbar-h',
+    document.getElementById('topBar').offsetHeight+'px');
+}
+window.addEventListener('load',updateTop);
+new ResizeObserver(updateTop).observe(document.getElementById('topBar'));
+
 const colours=['#e74c3c','#3498db','#1abc9c','#f1c40f','#9b59b6','#e67e22','#2ecc71','#8e44ad'];
 let datasets=[];
 let logY=false, normalized=false;
@@ -137,18 +144,6 @@ function refreshColours(){
 const cursor={x:null,y:null};
 const crosshair={
   id:'crosshair',
-  afterEvent(chart,evt){
-    const type=evt.event.type;
-    if(type==='mousemove'){
-
-      cursor.x=evt.event.offsetX; cursor.y=evt.event.offsetY;
-
-      chart.draw();
-    }else if(type==='mouseout'||type==='mouseleave'){
-      cursor.x=null; cursor.y=null; document.getElementById('cursorData').textContent='';
-      chart.draw();
-    }
-  },
   afterDraw(chart){
     if(cursor.x===null) return;
     const {ctx,chartArea:{top,bottom,left,right}}=chart;
@@ -184,6 +179,22 @@ const chart=new Chart(document.getElementById('cmpChart').getContext('2d'),{
     scales:{x:{type:'linear',title:{display:true,text:'λ (nm)'}},
             y:{title:{display:true,text:'Intensità (a.u.)'}}}
   }
+});
+
+const canvas=document.getElementById('cmpChart');
+canvas.addEventListener('mousemove',evt=>{
+  const rect=canvas.getBoundingClientRect();
+  cursor.x=evt.clientX-rect.left;
+  cursor.y=evt.clientY-rect.top;
+  chart.draw();
+  const xVal=chart.scales.x.getValueForPixel(cursor.x);
+  const yVal=chart.scales.y.getValueForPixel(cursor.y);
+  document.getElementById('cursorData').textContent=`λ ${xVal.toFixed(1)} nm | ${yVal.toFixed(2)}`;
+});
+canvas.addEventListener('mouseleave',()=>{
+  cursor.x=null; cursor.y=null;
+  document.getElementById('cursorData').textContent='';
+  chart.draw();
 });
 
 (async function loadList(){

--- a/index.html
+++ b/index.html
@@ -59,7 +59,12 @@
       width: 70px;
     }
     #title { margin-top: 0; }
-    .controls { margin-bottom: 15px; display: flex; gap: 10px; align-items: center; }
+    .controls { margin-bottom: 15px; display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+    .sliderRow { display: flex; gap: 20px; margin-bottom: 15px; flex-wrap: wrap; }
+    .slider { flex: 1; display: flex; gap: 8px; align-items: center; background: #fff; padding: 6px 10px; border-radius: 4px; box-shadow: 0 1px 3px rgba(0,0,0,0.2); }
+    .slider label { white-space: nowrap; }
+    .slider span { min-width: 24px; text-align: center; font-weight: bold; }
+    .slider input[type=range] { flex: 1; }
     canvas { width: 100% !important; }
     #specChart { height: 400px !important; border-radius: 4px; }
     #ccdCanvas { width: 100%; height: 200px; border: 1px solid #7f8c8d; margin-top: 5px; border-radius: 4px; }
@@ -91,15 +96,17 @@
   <div id="content">
     <h2 id="title">Seleziona uno spettro</h2>
     <div class="controls" id="seriesControls"></div>
-    <div class="controls">
-      <label for="threshSlider">Soglia (%)</label>
-      <input type="range" id="threshSlider" min="0" max="100" step="1" value="0">
-      <span id="threshValue">0</span>
-    </div>
-    <div class="controls">
-      <label for="widthSlider">Spessore (px)</label>
-      <input type="range" id="widthSlider" min="1" max="5" step="1" value="2">
-      <span id="widthValue">2</span>
+    <div class="sliderRow">
+      <div class="slider">
+        <label for="threshSlider">Soglia (%)</label>
+        <input type="range" id="threshSlider" min="0" max="100" step="1" value="0">
+        <span id="threshValue">0</span>
+      </div>
+      <div class="slider">
+        <label for="widthSlider">Spessore (px)</label>
+        <input type="range" id="widthSlider" min="1" max="5" step="1" value="2">
+        <span id="widthValue">2</span>
+      </div>
     </div>
     <div class="chart-container"><canvas id="specChart"></canvas></div>
     <h3>Simulazione CCD</h3>


### PR DESCRIPTION
## Summary
- fix crosshair plugin on compare page and improve top bar layout
- ensure the chart stays below the bar even when chips wrap
- redesign sliders on the homepage so threshold and thickness are side by side

## Testing
- `python -m py_compile labparser.py spectra_lab_viewer.py`

------
https://chatgpt.com/codex/tasks/task_e_6851622ad094832db9bc88f656dc13ed